### PR TITLE
Update npm lint command

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -16,7 +16,7 @@ If you want to contribute but don’t know what to do, take a look at these two 
 Run linters:
 
 ```bash
-npm lint
+npm run lint
 ```
 
 **Don’t forget to add tests and update documentation for your changes.**


### PR DESCRIPTION
The command to run the linters should be `npm run lint` and not `npm lint`. An alternative is `yarn lint`