### PR TITLE
Add Singapore as a location for GoJek

### DIFF
--- a/data/single/go-JEK.js
+++ b/data/single/go-JEK.js
@@ -658,5 +658,18 @@ module.exports = [
       },
       place_id: 'ChIJM8Svrubpiy0RXgXGfBxaLLk'
     }
+  },
+  {
+    name: 'Singapore',
+    company: 'go-JEK',
+    info: {
+      formatted_address: 'Singapore',
+      country: {
+        long_name: 'Singapore',
+        short_name: 'SG',
+        types: ['country', 'political']
+      },
+      place_id: 'ChIJdZOLiiMR2jERxPWrUs9peIg'
+    }
   }
 ]


### PR DESCRIPTION
GoJek provides its services in [Singapore as well.](https://www.gojek.com/sg/)